### PR TITLE
Fix spec to correctly detect no deprecations

### DIFF
--- a/spec/selector-linter-spec.coffee
+++ b/spec/selector-linter-spec.coffee
@@ -153,7 +153,7 @@ describe "SelectorLinter", ->
         packageName: "the-package",
         sourcePath: "index.less"
       })
-      expect(linter.getDeprecations()).toEqual []
+      expect(linter.getDeprecations()).toEqual({})
 
     it "records deprecations in the CSS", ->
       expectDeprecation(


### PR DESCRIPTION
Noticed this :microscope: while looking into https://github.com/atom/atom/issues/6869#issuecomment-104019059. Currently, the specs are failing with:

```
SelectorLinter
  ::checkUIStylesheet(css, metadata)
    it suggests using the shadow DOM psuedo selectors or the context stylesheet
      Expected {  } to equal [  ].
        at expectNoDeprecations (/Users/izuzak/github/atom-selector-linter/spec/selector-linter-spec.coffee:156:40)
        at [object Object].<anonymous> (/Users/izuzak/github/atom-selector-linter/spec/selector-linter-spec.coffee:165:7)
      Expected {  } to equal [  ].
        at expectNoDeprecations (/Users/izuzak/github/atom-selector-linter/spec/selector-linter-spec.coffee:156:40)
        at [object Object].<anonymous> (/Users/izuzak/github/atom-selector-linter/spec/selector-linter-spec.coffee:166:7)
      Expected {  } to equal [  ].
        at expectNoDeprecations (/Users/izuzak/github/atom-selector-linter/spec/selector-linter-spec.coffee:156:40)
        at [object Object].<anonymous> (/Users/izuzak/github/atom-selector-linter/spec/selector-linter-spec.coffee:167:7)


Finished in 1.015 seconds
31 tests, 53 assertions, 3 failures, 0 skipped
```

`deprecations` are stored in an object, not an array, so this switches the check to use an empty object, [similar to the check a few lines below](https://github.com/atom/atom-selector-linter/blob/f430a0a8fc29a9d90582e038fbbc6570cf5c95d5/spec/selector-linter-spec.coffee#L200) the modified line.

cc @kevinsawicki for :eyes:  (I don't have publish access for npm for this either, I believe, so will need a hand with publishing a new version if this is merged)
